### PR TITLE
feat: Allow passing headers from League emitter.

### DIFF
--- a/src/LeagueEvent/EnqueueListener.php
+++ b/src/LeagueEvent/EnqueueListener.php
@@ -34,6 +34,10 @@ final class EnqueueListener extends AbstractListener
      */
     public function handle(EventInterface $event)
     {
-        $this->publisher->publish($this->serializer->serialize($event), $event->getName());
+        $headers = [];
+        if (func_num_args() > 1) {
+            $headers = func_get_arg(1);
+        }
+        $this->publisher->publish($this->serializer->serialize($event), $event->getName(), $headers);
     }
 }

--- a/tests/unit/LeagueEvent/EnqueueListenerTest.php
+++ b/tests/unit/LeagueEvent/EnqueueListenerTest.php
@@ -4,6 +4,7 @@ namespace Burrow\tests\LeagueEvent;
 use Burrow\LeagueEvent\EnqueueListener;
 use Burrow\LeagueEvent\EventSerializer;
 use Burrow\QueuePublisher;
+use League\Event\Emitter;
 use League\Event\Event;
 use Mockery;
 
@@ -45,8 +46,23 @@ class EnqueueListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->serializer->shouldReceive('serialize')->with($event)->andReturn('serialized');
 
-        $this->queuePublisher->shouldReceive('publish')->with('serialized', 'SomethingHappened')->once();
+        $this->queuePublisher->shouldReceive('publish')->with('serialized', 'SomethingHappened', [])->once();
 
         $this->listener->handle($event);
+    }
+
+    /**
+     * @test
+     */
+    public function it_publishes_the_event_in_the_QueuePublisher_with_headers()
+    {
+        $emitter = new Emitter();
+        $emitter->addListener('SomethingHappened',$this->listener);
+        $event = new Event('SomethingHappened');
+
+        $this->serializer->shouldReceive('serialize')->with($event)->andReturn('serialized');
+        $this->queuePublisher->shouldReceive('publish')->with('serialized', 'SomethingHappened', ['header' => "foobar"])->once();
+
+        $emitter->emit($event, ['header' => "foobar"]);
     }
 }


### PR DESCRIPTION
Burrow allow passing headers from its publishers.
Burrow-tools does not take advantage of that with `League Event` library.