### PR TITLE
feat: Improve passing headers by injecting a factory.

### DIFF
--- a/src/EmptyHeadersFactory.php
+++ b/src/EmptyHeadersFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Burrow;
+
+class EmptyHeadersFactory implements HeadersFactory
+{
+    /**
+     * @return array
+     */
+    public function headers()
+    {
+        return [];
+    }
+}

--- a/src/HeadersFactory.php
+++ b/src/HeadersFactory.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Burrow;
+
+interface HeadersFactory
+{
+    /**
+     * @return array
+     */
+    public function headers();
+}

--- a/src/LeagueEvent/EnqueueListener.php
+++ b/src/LeagueEvent/EnqueueListener.php
@@ -1,6 +1,8 @@
 <?php
 namespace Burrow\LeagueEvent;
 
+use Burrow\EmptyHeadersFactory;
+use Burrow\HeadersFactory;
 use Burrow\QueuePublisher;
 use League\Event\AbstractListener;
 use League\Event\EventInterface;
@@ -12,6 +14,10 @@ final class EnqueueListener extends AbstractListener
 
     /** @var EventSerializer */
     private $serializer;
+    /**
+     * @var Headersfactory
+     */
+    private $headersfactory;
 
     /**
      * EnqueueListener constructor.
@@ -23,6 +29,12 @@ final class EnqueueListener extends AbstractListener
     {
         $this->publisher = $publisher;
         $this->serializer = $serializer;
+        $this->headersfactory = new EmptyHeadersFactory();
+    }
+
+    public function setHeadersFactory(HeadersFactory $headersFactory)
+    {
+        $this->headersfactory = $headersFactory;
     }
 
     /**
@@ -34,10 +46,7 @@ final class EnqueueListener extends AbstractListener
      */
     public function handle(EventInterface $event)
     {
-        $headers = [];
-        if (func_num_args() > 1) {
-            $headers = func_get_arg(1);
-        }
+        $headers = $this->headersfactory->headers();
         $this->publisher->publish($this->serializer->serialize($event), $event->getName(), $headers);
     }
 }


### PR DESCRIPTION
Relying on arguments unsigned in `EnqueueListener` to pass headers was a bit tricky.
It is a more elegant way to pass headers. The idea comes from @SelrahcD.

It is a BC break of the previous version.